### PR TITLE
feat: support setting a plan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,26 +1,15 @@
 name: octoDNS CloudflareProvider
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
-  config:
-    runs-on: ubuntu-latest
-    outputs:
-      json: ${{ steps.load.outputs.json }}
-    steps:
-    - id: load
-      run: |
-        {
-          echo 'json<<EOF'
-          curl -L https://github.com/octodns/octodns/raw/main/.ci-config.json
-          echo EOF
-        } >> $GITHUB_OUTPUT
   ci:
-    needs: config
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(needs.config.outputs.json).python_versions_active }}
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
@@ -32,14 +21,13 @@ jobs:
         run: |
           ./script/cibuild
   setup-py:
-    needs: config
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ fromJson(needs.config.outputs.json).python_version_current }}
+          python-version: "3.13"
           architecture: x64
       - name: CI setup.py
         run: |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ providers:
     #cdn: false
     # Manage Page Rules (URLFWD) records
     # pagerules: true
+    # Optional. Define Cloudflare plan type for the zones. Default: free,
+    # options: free, enterprise
+    #plan_type: free
     # Optional. Default: 4. Number of times to retry if a 429 response
     # is received.
     #retry_count: 4


### PR DESCRIPTION
This pull request includes updates to the `README.md` file, and enhancements to the `octodns_cloudflare` module to support Cloudflare plan types.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57-R59): Added documentation for the optional `plan_type` parameter, which defines the Cloudflare plan type for the zones.

### Cloudflare Provider Enhancements:
* [`octodns_cloudflare/__init__.py`](diffhunk://#diff-d6838eda1567eb5fb2b061691b90a5092cc1cf8954393cb240eb16a946206db1R92): Added support for the `plan_type` parameter in the `__init__` method. Updated logging to include the `plan_type`. [[1]](diffhunk://#diff-d6838eda1567eb5fb2b061691b90a5092cc1cf8954393cb240eb16a946206db1R92) [[2]](diffhunk://#diff-d6838eda1567eb5fb2b061691b90a5092cc1cf8954393cb240eb16a946206db1L102-R108) [[3]](diffhunk://#diff-d6838eda1567eb5fb2b061691b90a5092cc1cf8954393cb240eb16a946206db1R127)
* [`octodns_cloudflare/__init__.py`](diffhunk://#diff-d6838eda1567eb5fb2b061691b90a5092cc1cf8954393cb240eb16a946206db1R1176-R1206): Implemented methods `_current_plan`, `_supported_plans`, and `_update_plan` to manage Cloudflare plans. Updated the `_apply` method to handle plan updates. [[1]](diffhunk://#diff-d6838eda1567eb5fb2b061691b90a5092cc1cf8954393cb240eb16a946206db1R1176-R1206) [[2]](diffhunk://#diff-d6838eda1567eb5fb2b061691b90a5092cc1cf8954393cb240eb16a946206db1R1220-R1227)